### PR TITLE
fix: 破壊的変更が実行される可能性がある

### DIFF
--- a/Editor/OverrideValuesOnBuildPlugin.cs
+++ b/Editor/OverrideValuesOnBuildPlugin.cs
@@ -45,7 +45,7 @@ namespace Narazaka.VRChat.OverrideValuesOnBuild.Editor
             {
                 return;
             }
-            if (ov.target == null || ov.overrideValues == null || ov.overrideValues.Length == 0)
+            if (ov.target == null || !ov.target.transform.IsChildOf(ctx.AvatarRootTransform) || ov.overrideValues == null || ov.overrideValues.Length == 0)
             {
                 return;
             }


### PR DESCRIPTION
アバター外のObjectを(誤って?)対象にすると、ビルド時にそのプロパティを破壊的に置き換える問題を修正します。

ユーザーが意図的に設定する可能性は低い一方で、コンポーネントのアバター間のコピーだけで発生するので、今は無視しているだけですが、意図しない操作の可能性として、エラーか警告は出した方が良いかもしれません